### PR TITLE
Bugfix for #139

### DIFF
--- a/src/main/java/thaumicenergistics/container/ContainerPartArcaneCraftingTerminal.java
+++ b/src/main/java/thaumicenergistics/container/ContainerPartArcaneCraftingTerminal.java
@@ -1450,8 +1450,8 @@ public class ContainerPartArcaneCraftingTerminal
 	{
 		if( ( slotID == this.resultSlotNumber ) && ( button == GuiHelper.MOUSE_BUTTON_RIGHT ) )
 		{
-			// Ignore if result slot is right clicked.
-			return null;
+			// If right clicking on result slot, change it to left click
+			return super.slotClick( slotID, 0, flag, player );
 		}
 
 		// Pass to super

--- a/src/main/java/thaumicenergistics/container/ContainerWithNetworkTool.java
+++ b/src/main/java/thaumicenergistics/container/ContainerWithNetworkTool.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import thaumicenergistics.container.slot.SlotNetworkTool;
 import thaumicenergistics.container.slot.SlotRestrictive;
 import appeng.api.AEApi;
+import appeng.api.definitions.IItemDefinition;
 import appeng.api.implementations.guiobjects.IGuiItem;
 import appeng.api.implementations.guiobjects.INetworkTool;
 import appeng.api.implementations.items.IUpgradeModule;
@@ -112,59 +113,66 @@ public abstract class ContainerWithNetworkTool
 	protected void bindToNetworkTool( final InventoryPlayer playerInventory, final DimensionalCoord partLocation, final int slotOffsetX,
 										final int slotOffsetY )
 	{
-		// Check the player inventory for the network tool
-		for( int slotIndex = 0; slotIndex < playerInventory.getSizeInventory(); slotIndex++ )
+		//Get the networkTool or null if absent (e.g. disabled in AE's config-file)
+		ItemStack nwTool = AEApi.instance().definitions().items().networkTool().maybeStack( 1 ).orNull();
+		
+		//First of all is there a networkTool?
+		if(nwTool != null)
 		{
-			// Get the item in the current slot
-			ItemStack stack = playerInventory.getStackInSlot( slotIndex );
-
-			// Is it the network tool?
-			if( ( stack != null ) && ( stack.isItemEqual( AEApi.instance().definitions().items().networkTool().maybeStack( 1 ).get() ) ) )
+			// Check the player inventory for the network tool
+			for( int slotIndex = 0; slotIndex < playerInventory.getSizeInventory(); slotIndex++ )
 			{
-				// Get the gui item for the tool
-				IGuiItem guiItem = (IGuiItem)stack.getItem();
-
-				// Get the gui for the tool
-				INetworkTool networkTool = (INetworkTool)guiItem.getGuiObject( stack, partLocation.getWorld(), partLocation.x, partLocation.y,
-					partLocation.z );
-
-				Slot toolSlot = null;
-
-				// Add a slot for each network tool slot
-				for( int column = 0; column < ContainerWithNetworkTool.TOOL_COLUMNS; column++ )
+				// Get the item in the current slot
+				ItemStack stack = playerInventory.getStackInSlot( slotIndex );
+	
+				// Is it the network tool?
+				if( ( stack != null ) && ( stack.isItemEqual( AEApi.instance().definitions().items().networkTool().maybeStack( 1 ).get() ) ) )
 				{
-					for( int row = 0; row < ContainerWithNetworkTool.TOOL_ROWS; row++ )
+					// Get the gui item for the tool
+					IGuiItem guiItem = (IGuiItem)stack.getItem();
+	
+					// Get the gui for the tool
+					INetworkTool networkTool = (INetworkTool)guiItem.getGuiObject( stack, partLocation.getWorld(), partLocation.x, partLocation.y,
+						partLocation.z );
+	
+					Slot toolSlot = null;
+	
+					// Add a slot for each network tool slot
+					for( int column = 0; column < ContainerWithNetworkTool.TOOL_COLUMNS; column++ )
 					{
-						// Calculate the tools slot index
-						int slotToolIndex = column + ( row * ContainerWithNetworkTool.TOOL_COLUMNS );
-
-						// Create the slot
-						toolSlot = new SlotNetworkTool( networkTool, slotToolIndex, ContainerWithNetworkTool.TOOL_SLOT_X_OFFSET + slotOffsetX +
-										( column * ContainerWithPlayerInventory.SLOT_SIZE ), ( row * ContainerWithPlayerInventory.SLOT_SIZE ) +
-										ContainerWithNetworkTool.TOOL_SLOT_Y_OFFSET + slotOffsetY );
-
-						// Add the slot
-						this.addSlotToContainer( toolSlot );
-
-						// Check first
-						if( slotToolIndex == 0 )
+						for( int row = 0; row < ContainerWithNetworkTool.TOOL_ROWS; row++ )
 						{
-							this.firstToolSlotNumber = toolSlot.slotNumber;
+							// Calculate the tools slot index
+							int slotToolIndex = column + ( row * ContainerWithNetworkTool.TOOL_COLUMNS );
+	
+							// Create the slot
+							toolSlot = new SlotNetworkTool( networkTool, slotToolIndex, ContainerWithNetworkTool.TOOL_SLOT_X_OFFSET + slotOffsetX +
+											( column * ContainerWithPlayerInventory.SLOT_SIZE ), ( row * ContainerWithPlayerInventory.SLOT_SIZE ) +
+											ContainerWithNetworkTool.TOOL_SLOT_Y_OFFSET + slotOffsetY );
+	
+							// Add the slot
+							this.addSlotToContainer( toolSlot );
+	
+							// Check first
+							if( slotToolIndex == 0 )
+							{
+								this.firstToolSlotNumber = toolSlot.slotNumber;
+							}
 						}
 					}
+	
+					// Set last
+					if( toolSlot != null )
+					{
+						this.lastToolSlotNumber = toolSlot.slotNumber;
+					}
+	
+					// Mark that we have a network tool
+					this.hasNetworkTool = true;
+	
+					// Done
+					return;
 				}
-
-				// Set last
-				if( toolSlot != null )
-				{
-					this.lastToolSlotNumber = toolSlot.slotNumber;
-				}
-
-				// Mark that we have a network tool
-				this.hasNetworkTool = true;
-
-				// Done
-				return;
 			}
 		}
 	}


### PR DESCRIPTION
I think I found a fix for #139 .
If you change the right click on the result slot into a left click and call super, the stack splitting will not be executed.