### PR TITLE
fixing crashes with newer AE2 rv3 versions (>9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ group= "thaumicenergistics" // http://maven.apache.org/guides/mini/guide-naming-
 archivesBaseName = "thaumicenergistics"
 
 minecraft {
-    version = "1.7.10-10.13.4.1448-1.7.10"
+    version = "1.7.10-10.13.4.1558-1.7.10"
     runDir = "eclipse/assets"
 }
 
@@ -39,11 +39,16 @@ repositories {
         name "ic2"
         url "http://maven.ic2.player.to/"
     }
+    ivy {
+        name = 'ThaumCraft 4 API'
+        artifactPattern 'https://dl.dropboxusercontent.com/u/47135879/[module](-[classifier])-1.7.10-[revision](.[ext])'
+    }
 }
 
 dependencies {
     compile "mcp.mobius.waila:Waila:1.5.10_1.7.10"
     compile "net.industrial-craft:industrialcraft-2:2.2.726-experimental:api"
+    compile "Azanor:Thaumcraft:4.2.3.5:deobf@jar"
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
     //compile "some.group:artifact:version:classifier"

--- a/src/main/java/thaumicenergistics/container/ContainerEssentiaCell.java
+++ b/src/main/java/thaumicenergistics/container/ContainerEssentiaCell.java
@@ -1,6 +1,12 @@
 package thaumicenergistics.container;
 
-import java.util.ArrayList;
+import appeng.api.networking.security.IActionHost;
+import appeng.api.networking.security.PlayerSource;
+import appeng.api.storage.IMEInventoryHandler;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.ISaveProvider;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.tile.storage.TileChest;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
@@ -17,14 +23,8 @@ import thaumicenergistics.network.packet.client.PacketClientEssentiaCellTerminal
 import thaumicenergistics.network.packet.server.PacketServerEssentiaCellTerminal;
 import thaumicenergistics.util.EffectiveSide;
 import thaumicenergistics.util.PrivateInventory;
-import appeng.api.networking.security.IActionHost;
-import appeng.api.networking.security.PlayerSource;
-import appeng.api.storage.IMEInventoryHandler;
-import appeng.api.storage.IMEMonitor;
-import appeng.api.storage.ISaveProvider;
-import appeng.api.storage.StorageChannel;
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.tile.storage.TileChest;
+
+import java.util.ArrayList;
 
 /**
  * Inventory container for essentia cells in a ME chest.
@@ -107,13 +107,13 @@ public class ContainerEssentiaCell
 			try
 			{
 				// Get the chest handler
-				IMEInventoryHandler<IAEFluidStack> handler = this.hostChest.getHandler( StorageChannel.FLUIDS );
+				IMEInventoryHandler<IAEFluidStack> handler = null; // this.hostChest.getHandler(StorageChannel.FLUIDS ); TODO: Fix this!
 
 				// Get the monitor
 				if( handler != null )
 				{
 					// Create the essentia monitor
-					this.monitor = new EssentiaMonitor( (IMEMonitor<IAEFluidStack>)handler, this.hostChest.getProxy().getEnergy(), this );
+					this.monitor = new EssentiaMonitor((IMEMonitor<IAEFluidStack>)handler, this.hostChest.getProxy().getEnergy(), this );
 
 					// Attach to the monitor
 					this.attachToMonitor();

--- a/src/main/java/thaumicenergistics/container/ContainerPartArcaneCraftingTerminal.java
+++ b/src/main/java/thaumicenergistics/container/ContainerPartArcaneCraftingTerminal.java
@@ -1,7 +1,22 @@
 package thaumicenergistics.container;
 
-import java.util.ArrayList;
-import java.util.List;
+import appeng.api.AEApi;
+import appeng.api.config.Actionable;
+import appeng.api.config.SortDir;
+import appeng.api.config.SortOrder;
+import appeng.api.config.ViewItems;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.networking.security.PlayerSource;
+import appeng.api.networking.storage.IBaseMonitor;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.IMEMonitorHandlerReceiver;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+import appeng.container.implementations.ContainerCraftAmount;
+import appeng.core.sync.GuiBridge;
+import appeng.util.Platform;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.entity.player.EntityPlayer;
@@ -25,23 +40,9 @@ import thaumicenergistics.parts.AEPartArcaneCraftingTerminal;
 import thaumicenergistics.util.EffectiveSide;
 import thaumicenergistics.util.GuiHelper;
 import thaumicenergistics.util.ThEUtils;
-import appeng.api.AEApi;
-import appeng.api.config.Actionable;
-import appeng.api.config.SortDir;
-import appeng.api.config.SortOrder;
-import appeng.api.config.ViewItems;
-import appeng.api.networking.security.BaseActionSource;
-import appeng.api.networking.security.PlayerSource;
-import appeng.api.networking.storage.IBaseMonitor;
-import appeng.api.storage.IMEMonitor;
-import appeng.api.storage.IMEMonitorHandlerReceiver;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.api.storage.data.IItemList;
-import appeng.container.implementations.ContainerCraftAmount;
-import appeng.core.sync.GuiBridge;
-import appeng.util.Platform;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ContainerPartArcaneCraftingTerminal
 	extends ContainerWithPlayerInventory
@@ -924,8 +925,8 @@ public class ContainerPartArcaneCraftingTerminal
 		{
 			ContainerCraftAmount cca = (ContainerCraftAmount)this.player.openContainer;
 
-			cca.craftingItem.putStack( result.getItemStack() );
-			cca.whatToMake = result;
+			cca.getCraftingItem().putStack( result.getItemStack() );
+			cca.setItemToCraft(result);
 
 			cca.detectAndSendChanges();
 		}

--- a/src/main/java/thaumicenergistics/gui/GuiArcaneCraftingTerminal.java
+++ b/src/main/java/thaumicenergistics/gui/GuiArcaneCraftingTerminal.java
@@ -1,7 +1,15 @@
 package thaumicenergistics.gui;
 
-import java.util.ArrayList;
-import java.util.List;
+import appeng.api.config.*;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+import appeng.client.gui.widgets.ISortSource;
+import appeng.client.me.ItemRepo;
+import appeng.client.render.AppEngRenderItem;
+import appeng.core.AEConfig;
+import appeng.util.Platform;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiTextField;
@@ -16,13 +24,7 @@ import thaumcraft.common.config.Config;
 import thaumicenergistics.container.ContainerPartArcaneCraftingTerminal;
 import thaumicenergistics.container.ContainerPartArcaneCraftingTerminal.ArcaneCrafingCost;
 import thaumicenergistics.gui.abstraction.AbstractGuiConstantsACT;
-import thaumicenergistics.gui.buttons.GuiButtonClearCraftingGrid;
-import thaumicenergistics.gui.buttons.GuiButtonSearchMode;
-import thaumicenergistics.gui.buttons.GuiButtonSortingDirection;
-import thaumicenergistics.gui.buttons.GuiButtonSortingMode;
-import thaumicenergistics.gui.buttons.GuiButtonSwapArmor;
-import thaumicenergistics.gui.buttons.GuiButtonTerminalStyle;
-import thaumicenergistics.gui.buttons.GuiButtonViewType;
+import thaumicenergistics.gui.buttons.*;
 import thaumicenergistics.gui.widget.AbstractWidget;
 import thaumicenergistics.gui.widget.WidgetAEItem;
 import thaumicenergistics.integration.tc.MEItemAspectBridgeContainer;
@@ -32,21 +34,9 @@ import thaumicenergistics.registries.ThEStrings;
 import thaumicenergistics.texture.AEStateIconsEnum;
 import thaumicenergistics.texture.GuiTextureManager;
 import thaumicenergistics.util.GuiHelper;
-import appeng.api.config.SearchBoxMode;
-import appeng.api.config.Settings;
-import appeng.api.config.SortDir;
-import appeng.api.config.SortOrder;
-import appeng.api.config.TerminalStyle;
-import appeng.api.config.ViewItems;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.api.storage.data.IItemList;
-import appeng.client.gui.widgets.ISortSource;
-import appeng.client.me.ItemRepo;
-import appeng.client.render.AppEngRenderItem;
-import appeng.core.AEConfig;
-import appeng.util.Platform;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Gui for the Arcane Crafting Terminal
@@ -242,7 +232,7 @@ public class GuiArcaneCraftingTerminal
 			this.searchField.setText( "" );
 
 			// Update the repo
-			this.repo.searchString = "";
+			this.repo.setSearchString("");
 
 			// Repo needs update
 			this.viewNeedsUpdate = true;
@@ -810,10 +800,10 @@ public class GuiArcaneCraftingTerminal
 			String newSearch = this.searchField.getText().trim().toLowerCase();
 
 			// Has the query changed?
-			if( !newSearch.equals( this.repo.searchString ) )
+			if( !newSearch.equals( this.repo.getSearchString() ) )
 			{
 				// Set the search string
-				this.repo.searchString = newSearch;
+				this.repo.setSearchString(newSearch);
 
 				// Repo needs update
 				this.viewNeedsUpdate = true;
@@ -1144,7 +1134,7 @@ public class GuiArcaneCraftingTerminal
 		this.searchField.setFocused( ( searchBoxMode == SearchBoxMode.AUTOSEARCH ) || ( searchBoxMode == SearchBoxMode.NEI_AUTOSEARCH ) );
 
 		// Set the search string
-		this.searchField.setText( this.repo.searchString );
+		this.searchField.setText( this.repo.getSearchString() );
 
 		// Clear any existing buttons
 		this.buttonList.clear();

--- a/src/main/java/thaumicenergistics/gui/GuiEssentiaCellTerminal.java
+++ b/src/main/java/thaumicenergistics/gui/GuiEssentiaCellTerminal.java
@@ -1,8 +1,7 @@
 package thaumicenergistics.gui;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.GuiButton;
@@ -16,11 +15,7 @@ import org.lwjgl.opengl.GL11;
 import thaumcraft.api.aspects.Aspect;
 import thaumicenergistics.aspect.AspectStack;
 import thaumicenergistics.aspect.AspectStackComparator.ComparatorMode;
-import thaumicenergistics.container.AbstractContainerCellTerminalBase;
-import thaumicenergistics.container.ContainerEssentiaCell;
-import thaumicenergistics.container.ContainerEssentiaTerminal;
-import thaumicenergistics.container.ContainerWirelessEssentiaTerminal;
-import thaumicenergistics.container.IAspectSelectorContainer;
+import thaumicenergistics.container.*;
 import thaumicenergistics.gui.abstraction.AbstractGuiWithScrollbar;
 import thaumicenergistics.gui.buttons.GuiButtonSortingMode;
 import thaumicenergistics.gui.widget.AbstractWidget;
@@ -32,8 +27,10 @@ import thaumicenergistics.parts.AEPartEssentiaTerminal;
 import thaumicenergistics.registries.ThEStrings;
 import thaumicenergistics.texture.GuiTextureManager;
 import thaumicenergistics.util.GuiHelper;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Essentia terminal, wireless terminal, and cell(ME Chest) Gui.
@@ -346,12 +343,12 @@ public class GuiEssentiaCellTerminal
 		int overflowRows = (int)Math.ceil( overflowWidgets / GuiEssentiaCellTerminal.WIDGETS_PER_ROW );
 
 		// Update if the range has changed
-		if( overflowRows != this.scrollBar.getRange() )
-		{
+		//if( overflowRows != this.scrollBar.getRange() )  TODO: Fix this, too!
+		//{
 			// Update the scroll bar
 			this.scrollBar.setRange( 0, overflowRows, 1 );
 			this.onScrollbarMoved();
-		}
+		//}
 	}
 
 	/**

--- a/src/main/java/thaumicenergistics/gui/widget/WidgetAEItem.java
+++ b/src/main/java/thaumicenergistics/gui/widget/WidgetAEItem.java
@@ -1,13 +1,14 @@
 package thaumicenergistics.gui.widget;
 
-import java.util.List;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.client.render.AppEngRenderItem;
+import appeng.util.item.AEItemStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.client.render.AppEngRenderItem;
-import appeng.util.item.AEItemStack;
+
+import java.util.List;
 
 public class WidgetAEItem
 	extends AbstractWidget
@@ -60,7 +61,7 @@ public class WidgetAEItem
 			this.aeItemRenderer.zLevel = 2.0F;
 
 			// Set the item
-			this.aeItemRenderer.aeStack = this.aeItemStack;
+			this.aeItemRenderer.setAeStack(this.aeItemStack);
 
 			// Draw the item
 			this.aeItemRenderer.renderItemAndEffectIntoGUI( WidgetAEItem.MC.fontRenderer, WidgetAEItem.TEXTURE_MANAGER,

--- a/src/main/java/thaumicenergistics/items/ItemFocusAEWrench.java
+++ b/src/main/java/thaumicenergistics/items/ItemFocusAEWrench.java
@@ -154,7 +154,7 @@ public class ItemFocusAEWrench
 		CommonHelper.proxy.updateRenderMode( player );
 
 		// Set the eye height
-		PartPlacement.eyeHeight = eyeHeight;
+		PartPlacement.setEyeHeight(eyeHeight);
 
 		// Wrench the target
 		PartPlacement.place( wrench, position.blockX, position.blockY, position.blockZ, position.sideHit, player, player.worldObj,

--- a/src/main/java/thaumicenergistics/tileentities/TileArcaneAssembler.java
+++ b/src/main/java/thaumicenergistics/tileentities/TileArcaneAssembler.java
@@ -1,35 +1,5 @@
 package thaumicenergistics.tileentities;
 
-import io.netty.buffer.ByteBuf;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.List;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.world.World;
-import net.minecraftforge.common.util.ForgeDirection;
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.common.Thaumcraft;
-import thaumicenergistics.api.ThEApi;
-import thaumicenergistics.blocks.BlockArcaneAssembler;
-import thaumicenergistics.integration.IWailaSource;
-import thaumicenergistics.integration.tc.ArcaneCraftingPattern;
-import thaumicenergistics.integration.tc.DigiVisSourceData;
-import thaumicenergistics.integration.tc.IDigiVisSource;
-import thaumicenergistics.integration.tc.VisCraftingHelper;
-import thaumicenergistics.inventory.HandlerKnowledgeCore;
-import thaumicenergistics.items.ItemKnowledgeCore;
-import thaumicenergistics.util.EffectiveSide;
-import thaumicenergistics.util.GuiHelper;
-import thaumicenergistics.util.IInventoryUpdateReceiver;
-import thaumicenergistics.util.PrivateInventory;
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
@@ -66,6 +36,37 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.Thaumcraft;
+import thaumicenergistics.api.ThEApi;
+import thaumicenergistics.blocks.BlockArcaneAssembler;
+import thaumicenergistics.integration.IWailaSource;
+import thaumicenergistics.integration.tc.ArcaneCraftingPattern;
+import thaumicenergistics.integration.tc.DigiVisSourceData;
+import thaumicenergistics.integration.tc.IDigiVisSource;
+import thaumicenergistics.integration.tc.VisCraftingHelper;
+import thaumicenergistics.inventory.HandlerKnowledgeCore;
+import thaumicenergistics.items.ItemKnowledgeCore;
+import thaumicenergistics.util.EffectiveSide;
+import thaumicenergistics.util.GuiHelper;
+import thaumicenergistics.util.IInventoryUpdateReceiver;
+import thaumicenergistics.util.PrivateInventory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
 
 public class TileArcaneAssembler
 	extends AENetworkInvTile
@@ -311,7 +312,7 @@ public class TileArcaneAssembler
 			try
 			{
 				// Get the storage grid
-				IStorageGrid storageGrid = this.gridProxy.getStorage();
+				IStorageGrid storageGrid = this.getGridProxy().getStorage();
 
 				// Simulate placing the items
 				IAEItemStack rejected = storageGrid.getItemInventory().injectItems( this.currentPattern.result, Actionable.SIMULATE, this.mySource );
@@ -344,7 +345,7 @@ public class TileArcaneAssembler
 								this.warpPowerMultiplier;
 
 				// Attempt to take power
-				IEnergyGrid eGrid = this.gridProxy.getEnergy();
+				IEnergyGrid eGrid = this.getGridProxy().getEnergy();
 				double powerExtracted = eGrid.extractAEPower( powerRequired, Actionable.MODULATE, PowerMultiplier.CONFIG );
 
 				if( ( powerExtracted - powerRequired ) <= 0.0D )
@@ -433,7 +434,7 @@ public class TileArcaneAssembler
 		IDigiVisSource visSource = null;
 
 		// Ensure the grid is ready
-		if( !this.gridProxy.isReady() )
+		if( !this.getGridProxy().isReady() )
 		{
 			return;
 		}
@@ -441,7 +442,7 @@ public class TileArcaneAssembler
 		try
 		{
 			// Get the source
-			visSource = this.visSourceInfo.tryGetSource( this.gridProxy.getGrid() );
+			visSource = this.visSourceInfo.tryGetSource( this.getGridProxy().getGrid() );
 		}
 		catch( GridAccessException e )
 		{
@@ -584,7 +585,7 @@ public class TileArcaneAssembler
 		try
 		{
 			// Get the security grid
-			ISecurityGrid sGrid = this.gridProxy.getSecurity();
+			ISecurityGrid sGrid = this.getGridProxy().getSecurity();
 
 			// Return true if the player has inject and extract permissions
 			return( ( sGrid.hasPermission( player, SecurityPermissions.INJECT ) ) && ( sGrid.hasPermission( player, SecurityPermissions.EXTRACT ) ) );
@@ -733,10 +734,10 @@ public class TileArcaneAssembler
 		if( EffectiveSide.isServerSide() )
 		{
 			// Do we have a proxy and grid node?
-			if( ( this.gridProxy != null ) && ( this.gridProxy.getNode() != null ) )
+			if( ( this.getGridProxy() != null ) && ( this.getGridProxy().getNode() != null ) )
 			{
 				// Get the grid node activity
-				this.isActive = this.gridProxy.getNode().isActive();
+				this.isActive = this.getGridProxy().getNode().isActive();
 			}
 		}
 
@@ -755,7 +756,7 @@ public class TileArcaneAssembler
 	public void onBreak()
 	{
 		this.isCrafting = false;
-		this.gridProxy.invalidate();
+		this.getGridProxy().invalidate();
 	}
 
 	/**
@@ -979,7 +980,7 @@ public class TileArcaneAssembler
 	{
 		try
 		{
-			this.gridProxy.onReady();
+			this.getGridProxy().onReady();
 		}
 		catch( GridException e )
 		{
@@ -1119,12 +1120,12 @@ public class TileArcaneAssembler
 		}
 
 		// Are the network patterns stale?
-		if( this.stalePatterns && this.gridProxy.isReady() )
+		if( this.stalePatterns && this.getGridProxy().isReady() )
 		{
 			try
 			{
 				// Inform the network
-				this.gridProxy.getGrid().postEvent( new MENetworkCraftingPatternChange( this, this.getActionableNode() ) );
+				this.getGridProxy().getGrid().postEvent( new MENetworkCraftingPatternChange( this, this.getActionableNode() ) );
 
 				// Mark they are no longer stale
 				this.stalePatterns = false;
@@ -1246,7 +1247,7 @@ public class TileArcaneAssembler
 	 */
 	public void setOwner( final EntityPlayer player )
 	{
-		this.gridProxy.setOwner( player );
+		this.getGridProxy().setOwner( player );
 	}
 
 	/**
@@ -1258,10 +1259,10 @@ public class TileArcaneAssembler
 		if( FMLCommonHandler.instance().getEffectiveSide().isServer() )
 		{
 			// Set idle power usage
-			this.gridProxy.setIdlePowerUsage( TileArcaneAssembler.IDLE_POWER );
+			this.getGridProxy().setIdlePowerUsage( TileArcaneAssembler.IDLE_POWER );
 
 			// Set that we require a channel
-			this.gridProxy.setFlags( GridFlags.REQUIRE_CHANNEL );
+			this.getGridProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
 		}
 
 		return this;

--- a/src/main/java/thaumicenergistics/tileentities/TileEssentiaVibrationChamber.java
+++ b/src/main/java/thaumicenergistics/tileentities/TileEssentiaVibrationChamber.java
@@ -1,9 +1,13 @@
 package thaumicenergistics.tileentities;
 
+import appeng.api.config.Actionable;
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.energy.IEnergyGrid;
+import appeng.api.networking.ticking.IGridTickable;
+import appeng.api.networking.ticking.TickRateModulation;
+import appeng.api.networking.ticking.TickingRequest;
+import appeng.me.GridAccessException;
 import io.netty.buffer.ByteBuf;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -16,13 +20,10 @@ import thaumicenergistics.integration.tc.EssentiaTransportHelper;
 import thaumicenergistics.network.packet.AbstractPacket;
 import thaumicenergistics.registries.ThEStrings;
 import thaumicenergistics.tileentities.abstraction.TileEVCBase;
-import appeng.api.config.Actionable;
-import appeng.api.networking.IGridNode;
-import appeng.api.networking.energy.IEnergyGrid;
-import appeng.api.networking.ticking.IGridTickable;
-import appeng.api.networking.ticking.TickRateModulation;
-import appeng.api.networking.ticking.TickingRequest;
-import appeng.me.GridAccessException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Implements the logical functionality of the E.V.C.
@@ -249,7 +250,7 @@ public class TileEssentiaVibrationChamber
 		try
 		{
 			// Get the energy grid
-			IEnergyGrid eGrid = this.gridProxy.getEnergy();
+			IEnergyGrid eGrid = this.getProxy().getEnergy();
 
 			// Get rejected amount, note that any rejected amount is simply lost.
 			double rejectedPower = eGrid.injectPower( producedPower, Actionable.SIMULATE );

--- a/src/main/java/thaumicenergistics/tileentities/abstraction/TileEVCBase.java
+++ b/src/main/java/thaumicenergistics/tileentities/abstraction/TileEVCBase.java
@@ -1,7 +1,14 @@
 package thaumicenergistics.tileentities.abstraction;
 
+import appeng.api.config.Actionable;
+import appeng.api.util.AECableType;
+import appeng.api.util.DimensionalCoord;
+import appeng.tile.TileEvent;
+import appeng.tile.events.TileEventType;
+import appeng.tile.grid.AENetworkTile;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
-import java.io.IOException;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -14,14 +21,8 @@ import thaumicenergistics.api.ThEApi;
 import thaumicenergistics.aspect.AspectStack;
 import thaumicenergistics.integration.tc.IEssentiaTransportWithSimulate;
 import thaumicenergistics.util.EffectiveSide;
-import appeng.api.config.Actionable;
-import appeng.api.util.AECableType;
-import appeng.api.util.DimensionalCoord;
-import appeng.tile.TileEvent;
-import appeng.tile.events.TileEventType;
-import appeng.tile.grid.AENetworkTile;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+
+import java.io.IOException;
 
 /**
  * Essentia Vibration Chamber Base
@@ -383,7 +384,7 @@ public abstract class TileEVCBase
 		if( EffectiveSide.isServerSide() )
 		{
 			// Set idle power usage to zero
-			this.gridProxy.setIdlePowerUsage( 0.0D );
+			this.getProxy().setIdlePowerUsage( 0.0D );
 		}
 	}
 
@@ -409,7 +410,7 @@ public abstract class TileEVCBase
 	 */
 	public void setOwner( final EntityPlayer player )
 	{
-		this.gridProxy.setOwner( player );
+		this.getProxy().setOwner( player );
 	}
 
 	@Override

--- a/src/main/java/thaumicenergistics/tileentities/abstraction/TileProviderBase.java
+++ b/src/main/java/thaumicenergistics/tileentities/abstraction/TileProviderBase.java
@@ -1,19 +1,5 @@
 package thaumicenergistics.tileentities.abstraction;
 
-import io.netty.buffer.ByteBuf;
-import java.io.IOException;
-import java.util.List;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraftforge.common.util.ForgeDirection;
-import thaumcraft.api.aspects.Aspect;
-import thaumicenergistics.grid.IEssentiaGrid;
-import thaumicenergistics.grid.IMEEssentiaMonitor;
-import thaumicenergistics.integration.IWailaSource;
-import thaumicenergistics.registries.EnumCache;
-import thaumicenergistics.util.EffectiveSide;
 import appeng.api.config.Actionable;
 import appeng.api.implementations.tiles.IColorableTile;
 import appeng.api.networking.GridFlags;
@@ -33,6 +19,21 @@ import appeng.tile.networking.TileCableBus;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+import thaumcraft.api.aspects.Aspect;
+import thaumicenergistics.grid.IEssentiaGrid;
+import thaumicenergistics.grid.IMEEssentiaMonitor;
+import thaumicenergistics.integration.IWailaSource;
+import thaumicenergistics.registries.EnumCache;
+import thaumicenergistics.util.EffectiveSide;
+
+import java.io.IOException;
+import java.util.List;
 
 public abstract class TileProviderBase
 	extends AENetworkTile
@@ -165,7 +166,7 @@ public abstract class TileProviderBase
 		IGrid grid = null;
 
 		// Get the grid node
-		IGridNode node = this.gridProxy.getNode();
+		IGridNode node = this.getProxy().getNode();
 
 		// Ensure we have the node
 		if( node != null )
@@ -195,7 +196,7 @@ public abstract class TileProviderBase
 
 	/**
 	 * Called when the power goes on or off.
-	 * 
+	 *
 	 * @param isPowered
 	 */
 	protected void onPowerChange( final boolean isPowered )
@@ -205,26 +206,26 @@ public abstract class TileProviderBase
 	/**
 	 * Sets the color of the provider.
 	 * This does not set the isColorForced flag to true.
-	 * 
+	 *
 	 * @param gridColor
 	 */
 	protected void setProviderColor( final AEColor gridColor )
 	{
 		// Set our color to match
-		this.gridProxy.myColor = gridColor;
+		this.getProxy().setColor(gridColor);
 
 		// Are we server side?
 		if( EffectiveSide.isServerSide() )
 		{
 			/*
 			// Get the grid node
-			IGridNode gridNode = this.gridProxy.getNode();
+			IGridNode gridNode = this.getProxy().getNode();
 
 			// Do we have a grid node?
 			if( gridNode != null )
 			{
 				// Update the grid node
-				this.gridProxy.getNode().updateState();
+				this.getProxy().getNode().updateState();
 			}
 			*/
 
@@ -293,7 +294,7 @@ public abstract class TileProviderBase
 		AEColor[] sideColors = this.getNeighborCableColors();
 
 		// Get our current color
-		AEColor currentColor = this.gridProxy.myColor;
+		AEColor currentColor = this.getProxy().getColor();
 
 		// Are we attached to a side?
 		if( this.attachmentSide != ForgeDirection.UNKNOWN.ordinal() )
@@ -355,7 +356,7 @@ public abstract class TileProviderBase
 
 	/**
 	 * Returns how much of the specified aspect is in the network.
-	 * 
+	 *
 	 * @param searchAspect
 	 * @return
 	 */
@@ -384,17 +385,17 @@ public abstract class TileProviderBase
 	@Override
 	public AEColor getColor()
 	{
-		return this.gridProxy.myColor;
+		return this.getProxy().getColor();
 	}
 
 	public AEColor getGridColor()
 	{
-		return this.gridProxy.getGridColor();
+		return this.getProxy().getGridColor();
 	}
 
 	/**
 	 * Gets the machine source for the provider.
-	 * 
+	 *
 	 * @return
 	 */
 	public MachineSource getMachineSource()
@@ -410,10 +411,10 @@ public abstract class TileProviderBase
 			boolean prevActive = this.isActive;
 
 			// Do we have a proxy and grid node?
-			if( ( this.gridProxy != null ) && ( this.gridProxy.getNode() != null ) )
+			if( ( this.getProxy() != null ) && ( this.getProxy().getNode() != null ) )
 			{
 				// Get the grid node activity
-				this.isActive = this.gridProxy.getNode().isActive();
+				this.isActive = this.getProxy().getNode().isActive();
 
 				// Did the power state change?
 				if( prevActive != this.isActive )
@@ -533,18 +534,18 @@ public abstract class TileProviderBase
 
 	/**
 	 * Sets the owner of this tile.
-	 * 
+	 *
 	 * @param player
 	 */
 	public void setOwner( final EntityPlayer player )
 	{
-		this.gridProxy.setOwner( player );
+		this.getProxy().setOwner( player );
 	}
 
 	/**
 	 * Configures the provider based on the specified
 	 * attachment side.
-	 * 
+	 *
 	 * @param attachmentSide
 	 */
 	public void setupProvider( final int attachmentSide )
@@ -556,10 +557,10 @@ public abstract class TileProviderBase
 			this.attachmentSide = attachmentSide;
 
 			// Set that we require a channel
-			this.gridProxy.setFlags( GridFlags.REQUIRE_CHANNEL );
+			this.getProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
 
 			// Set the idle power usage
-			this.gridProxy.setIdlePowerUsage( this.getIdlePowerusage() );
+			this.getProxy().setIdlePowerUsage( this.getIdlePowerusage() );
 		}
 	}
 


### PR DESCRIPTION
This at least fixes all the crashes with the newer builds. Can provide a link to the jar if wanted because building this is a pain (you need BC, Rotarycraft, AE2, DragonAPI as dev/deobf versions plus CC API and the mekanism API).

This still has some issues, I am having issues on my private SMP server with the autocrafting not working correctly on some terminals sometimes which seems to be related to ThaumicEnergistics, but I do not see why my commits should do that. @Nividica you may want to check the TODO's I set up in there, these things may need some more rework because I could not find a way to correctly reproduce what you did in the original setting. Also built against newer forge and I added TC dev version to the build.gradle. You could probably add most of the mods via the build.gradle you need for compiling.