### PR TITLE
Update CurseMaven to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     runtime("com.brandon3055.brandonscore:BrandonsCore:${version_bc}:universal") {
         transitive = false
     }
+    runtime("curse.maven:codechickenlib:${version_ccl}") {
+        transitive = false
+    }
     runtime("com.brandon3055.projectintelligence:ProjectIntelligence:${version_pi}:universal") {
         transitive = false
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath "net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT"
-        classpath "com.wynprice.cursemaven:CurseMaven:1.1.0"
+        classpath "com.wynprice.cursemaven:CurseMaven:2.1.0"
     }
 }
 apply plugin: "net.minecraftforge.gradle.forge"
@@ -50,14 +50,14 @@ repositories {
 
 dependencies {
     provided "mezz.jei:jei_${version_jei}:api"
-    deobfCompile(curse.resolve("baubles", "${version_ba}"))
-    deobfCompile(curse.resolve("thaumcraft", "${version_tc}"))
+    deobfCompile("curse.maven:baubles:${version_ba}")
+    deobfCompile("curse.maven:thaumcraft:${version_tc}")
     deobfCompile("appeng:appliedenergistics2:${version_ae2}") {
         transitive = false
     }
     // Testing mods
     runtime "mezz.jei:jei_${version_jei}"
-    runtime(curse.resolve("thaumic-jei", "${version_tjei}")) {
+    runtime("curse.maven:thaumic-jei:${version_tjei}") {
         transitive = false
     }
     runtime("cofh:RedstoneFlux:${version_rf}:universal") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ version_ae2=rv6-stable-7
 
 # Optional/Runtime
 version_tjei=2705304
+version_ccl=2779848
 
 # In Game Information Book, Optional
 version_rf=1.12-2.1.0.7


### PR DESCRIPTION
Fixes download issues with recent changes by CurseForge.

Also adds missing codechickenlib to runtime.