### PR TITLE
Fix right-click not blocking other actions

### DIFF
--- a/src/main/java/thaumicenergistics/part/PartArcaneTerminal.java
+++ b/src/main/java/thaumicenergistics/part/PartArcaneTerminal.java
@@ -78,9 +78,12 @@ public class PartArcaneTerminal extends PartSharedTerminal {
 
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, Vec3d pos) {
-        if (ForgeUtil.isClient() || (player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
+        if ((player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
             return false;
-        GuiHandler.openGUI(ModGUIs.ARCANE_TERMINAL, player, this.hostTile.getPos(), this.side);
+
+        if (ForgeUtil.isServer())
+            GuiHandler.openGUI(ModGUIs.ARCANE_TERMINAL, player, this.hostTile.getPos(), this.side);
+
         return true;
     }
 

--- a/src/main/java/thaumicenergistics/part/PartEssentiaExportBus.java
+++ b/src/main/java/thaumicenergistics/part/PartEssentiaExportBus.java
@@ -122,9 +122,12 @@ public class PartEssentiaExportBus extends PartSharedEssentiaBus {
 
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, Vec3d vec3d) {
-        if (ForgeUtil.isClient() || (player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
+        if ((player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
             return false;
-        GuiHandler.openGUI(ModGUIs.ESSENTIA_EXPORT_BUS, player, this.hostTile.getPos(), this.side);
+
+        if (ForgeUtil.isServer())
+            GuiHandler.openGUI(ModGUIs.ESSENTIA_EXPORT_BUS, player, this.hostTile.getPos(), this.side);
+
         return true;
     }
 }

--- a/src/main/java/thaumicenergistics/part/PartEssentiaImportBus.java
+++ b/src/main/java/thaumicenergistics/part/PartEssentiaImportBus.java
@@ -104,9 +104,12 @@ public class PartEssentiaImportBus extends PartSharedEssentiaBus {
 
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, Vec3d vec3d) {
-        if (ForgeUtil.isClient() || (player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
+        if ((player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
             return false;
-        GuiHandler.openGUI(ModGUIs.ESSENTIA_IMPORT_BUS, player, this.hostTile.getPos(), this.side);
+
+        if (ForgeUtil.isServer())
+            GuiHandler.openGUI(ModGUIs.ESSENTIA_IMPORT_BUS, player, this.hostTile.getPos(), this.side);
+
         return true;
     }
 

--- a/src/main/java/thaumicenergistics/part/PartEssentiaStorageBus.java
+++ b/src/main/java/thaumicenergistics/part/PartEssentiaStorageBus.java
@@ -113,9 +113,12 @@ public class PartEssentiaStorageBus extends PartSharedEssentiaBus implements ICe
 
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, Vec3d vec3d) {
-        if (ForgeUtil.isClient() || (player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
+        if ((player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
             return false;
-        GuiHandler.openGUI(ModGUIs.ESSENTIA_STORAGE_BUS, player, this.hostTile.getPos(), this.side);
+
+        if (ForgeUtil.isServer())
+            GuiHandler.openGUI(ModGUIs.ESSENTIA_STORAGE_BUS, player, this.hostTile.getPos(), this.side);
+
         return true;
     }
 

--- a/src/main/java/thaumicenergistics/part/PartEssentiaTerminal.java
+++ b/src/main/java/thaumicenergistics/part/PartEssentiaTerminal.java
@@ -47,9 +47,12 @@ public class PartEssentiaTerminal extends PartSharedTerminal {
 
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, Vec3d pos) {
-        if (ForgeUtil.isClient() || (player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
+        if ((player.isSneaking() && AEUtil.isWrench(player.getHeldItem(hand), player, this.getTile().getPos())))
             return false;
-        GuiHandler.openGUI(ModGUIs.ESSENTIA_TERMINAL, player, this.hostTile.getPos(), this.side);
+
+        if (ForgeUtil.isServer())
+            GuiHandler.openGUI(ModGUIs.ESSENTIA_TERMINAL, player, this.hostTile.getPos(), this.side);
+
         return true;
     }
 


### PR DESCRIPTION
Resolves #389 

Client should return true even though the server will handle the GUI event.  It should only return false if we are expecting another code path (or mod) to handle the action.