### PR TITLE
Show Essentia amounts in Essentia Terminal

### DIFF
--- a/src/main/java/thaumicenergistics/client/gui/GuiBase.java
+++ b/src/main/java/thaumicenergistics/client/gui/GuiBase.java
@@ -20,14 +20,13 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextFormatting;
 
 import appeng.api.config.Settings;
-import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigurableObject;
 import appeng.client.gui.widgets.GuiImgButton;
 import appeng.client.gui.widgets.ITooltip;
-import appeng.client.render.StackSizeRenderer;
 
 import thaumicenergistics.api.storage.IAEEssentiaStack;
+import thaumicenergistics.client.gui.helpers.GenericStackSizeRenderer;
 import thaumicenergistics.container.ContainerBase;
 import thaumicenergistics.container.slot.ISlotOptional;
 import thaumicenergistics.container.slot.SlotGhostEssentia;
@@ -39,7 +38,7 @@ import thaumicenergistics.container.slot.ThESlot;
  */
 public abstract class GuiBase extends GuiContainer {
 
-    private static StackSizeRenderer stackSizeRenderer = new StackSizeRenderer();
+    private static final GenericStackSizeRenderer stackSizeRenderer = new GenericStackSizeRenderer();
 
     public GuiBase(ContainerBase container) {
         super(container);
@@ -64,10 +63,10 @@ public abstract class GuiBase extends GuiContainer {
             if (slot.isEnabled()) {
                 // TODO: Draw slot background on enabled slots
             }
-        } else if (slot instanceof SlotME && ((SlotME) slot).getAEStack() instanceof IAEItemStack) {
+        } else if (slot instanceof SlotME) {
             SlotME slotME = (SlotME) slot;
             super.drawSlot(slot);
-            stackSizeRenderer.renderStackSize(this.fontRenderer, (IAEItemStack) slotME.getAEStack(), slot.xPos, slot.yPos);
+            stackSizeRenderer.renderStackSize(this.fontRenderer, slotME.getAEStack(), slot.xPos, slot.yPos);
             return;
         } else if (slot instanceof ThESlot) {
             if (((ThESlot) slot).hasBackgroundIcon()) {
@@ -101,10 +100,7 @@ public abstract class GuiBase extends GuiContainer {
             }
             if (this.hoveredSlot instanceof SlotME && this.hoveredSlot.getHasStack() && ((SlotME) this.hoveredSlot).getAEStack() instanceof IAEEssentiaStack) {
                 IAEEssentiaStack stack = (IAEEssentiaStack) ((SlotME) this.hoveredSlot).getAEStack();
-                List<String> tooltip = new ArrayList<>();
-                tooltip.add(stack.getAspect().getName());
-                tooltip.add(Long.toString(stack.getStackSize()));
-                this.drawHoveringText(tooltip, mouseX, mouseY);
+                this.drawHoveringText(stack.getAspect().getName(), mouseX, mouseY);
                 return;
             }
         }

--- a/src/main/java/thaumicenergistics/client/gui/helpers/GenericStackSizeRenderer.java
+++ b/src/main/java/thaumicenergistics/client/gui/helpers/GenericStackSizeRenderer.java
@@ -1,0 +1,85 @@
+package thaumicenergistics.client.gui.helpers;
+
+import appeng.api.storage.data.IAEStack;
+import appeng.core.AEConfig;
+import appeng.core.localization.GuiText;
+import appeng.util.ISlimReadableNumberConverter;
+import appeng.util.IWideReadableNumberConverter;
+import appeng.util.ReadableNumberConverter;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GlStateManager;
+
+/**
+ * Based on StackSizeRenderer
+ * 
+ * Modified renderStackSize to accept a generic IAEStack
+ */
+public class GenericStackSizeRenderer
+{
+    private static final ISlimReadableNumberConverter SLIM_CONVERTER = ReadableNumberConverter.INSTANCE;
+    private static final IWideReadableNumberConverter WIDE_CONVERTER = ReadableNumberConverter.INSTANCE;
+
+    public void renderStackSize(FontRenderer fontRenderer, IAEStack<?> aeStack, int xPos, int yPos )
+    {
+        if( aeStack != null )
+        {
+            final float scaleFactor = AEConfig.instance().useTerminalUseLargeFont() ? 0.85f : 0.5f;
+            final float inverseScaleFactor = 1.0f / scaleFactor;
+            final int offset = AEConfig.instance().useTerminalUseLargeFont() ? 0 : -1;
+
+            final boolean unicodeFlag = fontRenderer.getUnicodeFlag();
+            fontRenderer.setUnicodeFlag( false );
+
+            if( aeStack.getStackSize() == 0 && aeStack.isCraftable() )
+            {
+                final String craftLabelText = AEConfig.instance().useTerminalUseLargeFont() ? GuiText.LargeFontCraft.getLocal() : GuiText.SmallFontCraft
+                        .getLocal();
+                GlStateManager.disableLighting();
+                GlStateManager.disableDepth();
+                GlStateManager.disableBlend();
+                GlStateManager.pushMatrix();
+                GlStateManager.scale( scaleFactor, scaleFactor, scaleFactor );
+                final int X = (int) ( ( (float) xPos + offset + 16.0f - fontRenderer.getStringWidth( craftLabelText ) * scaleFactor ) * inverseScaleFactor );
+                final int Y = (int) ( ( (float) yPos + offset + 16.0f - 7.0f * scaleFactor ) * inverseScaleFactor );
+                fontRenderer.drawStringWithShadow( craftLabelText, X, Y, 16777215 );
+                GlStateManager.popMatrix();
+                GlStateManager.enableLighting();
+                GlStateManager.enableDepth();
+                GlStateManager.enableBlend();
+            }
+
+            if( aeStack.getStackSize() > 0 )
+            {
+                final String stackSize = this.getToBeRenderedStackSize( aeStack.getStackSize() );
+
+                GlStateManager.disableLighting();
+                GlStateManager.disableDepth();
+                GlStateManager.disableBlend();
+                GlStateManager.pushMatrix();
+                GlStateManager.scale( scaleFactor, scaleFactor, scaleFactor );
+                final int X = (int) ( ( (float) xPos + offset + 16.0f - fontRenderer.getStringWidth( stackSize ) * scaleFactor ) * inverseScaleFactor );
+                final int Y = (int) ( ( (float) yPos + offset + 16.0f - 7.0f * scaleFactor ) * inverseScaleFactor );
+                fontRenderer.drawStringWithShadow( stackSize, X, Y, 16777215 );
+                GlStateManager.popMatrix();
+                GlStateManager.enableLighting();
+                GlStateManager.enableDepth();
+                GlStateManager.enableBlend();
+            }
+
+            fontRenderer.setUnicodeFlag( unicodeFlag );
+        }
+    }
+
+    private String getToBeRenderedStackSize( final long originalSize )
+    {
+        if( AEConfig.instance().useTerminalUseLargeFont() )
+        {
+            return SLIM_CONVERTER.toSlimReadableForm( originalSize );
+        }
+        else
+        {
+            return WIDE_CONVERTER.toWideReadableForm( originalSize );
+        }
+    }
+
+}


### PR DESCRIPTION
This was accomplished by creating a copy of AE2's `StackSizeRenderer` and allowing it to accept a generic `IAEStack<?>`. Then we can render Essentia using the same code path as items.

This change could be easily submitted to AE2, then the copied class wouldn't be necessary.